### PR TITLE
feat: fade the board's scroll edges

### DIFF
--- a/frontend/src/components/tasks/TaskBoard.vue
+++ b/frontend/src/components/tasks/TaskBoard.vue
@@ -1,5 +1,10 @@
 <template>
-	<ScrollArea orientation="horizontal" viewport-class="pb-3">
+	<ScrollArea
+		ref="scroller"
+		orientation="horizontal"
+		viewport-class="pb-3"
+		:style="{ maskImage: mask, WebkitMaskImage: mask }"
+	>
 		<div class="flex items-start gap-3">
 			<section
 				v-for="status in TASK_STATUSES"
@@ -44,11 +49,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import draggable from 'vuedraggable'
 import { Badge, ScrollArea } from 'frappe-ui'
 import TaskBoardCard from '@/components/tasks/TaskBoardCard.vue'
 import { usePinnedTasks } from '@/composables/usePinnedTasks'
+import { useScrollFade } from '@/composables/useScrollFade'
 import { useTaskMutations, type TaskListHandle } from '@/composables/useTaskMutations'
 import { dayjs, DATE_FORMAT } from '@/lib/dates'
 import { TASK_STATUSES, type HiveTask, type HiveTaskAssignee } from '@/types'
@@ -81,6 +87,15 @@ const NO_DATE = '9999-12-31'
 
 const { setStatus } = useTaskMutations(props.list)
 const { pinned } = usePinnedTasks()
+
+/** `ScrollArea` hands out its viewport through a plain getter, so read it once
+ *  the component is mounted rather than expecting a reactive value. */
+const scroller = ref<{ viewportElement: HTMLElement | null } | null>(null)
+const viewport = ref<HTMLElement | null>(null)
+const { mask } = useScrollFade(viewport, 'horizontal')
+onMounted(() => {
+	viewport.value = scroller.value?.viewportElement ?? null
+})
 
 const dragOptions = computed(() => ({
 	group: 'tasks',

--- a/frontend/src/composables/useScrollFade.ts
+++ b/frontend/src/composables/useScrollFade.ts
@@ -1,0 +1,74 @@
+import { onScopeDispose, ref, watch, type Ref } from 'vue'
+
+/** How wide each edge fade grows to, in px. */
+const FADE = 40
+/** Sub-pixel scroll sizes are never exactly equal; ignore the remainder. */
+const EPSILON = 1
+
+/**
+ * A `mask-image` that fades whichever edges of a scroller still have content
+ * past them, so a cut-off row reads as scrollable instead of chopped.
+ *
+ * Each fade grows with the distance left to scroll on that side, which means
+ * it eases in and out with the scroll itself — no transition to animate, and
+ * no fade at an edge you have already reached.
+ */
+export function useScrollFade(
+	element: Ref<HTMLElement | null | undefined>,
+	orientation: 'horizontal' | 'vertical' = 'horizontal',
+) {
+	const mask = ref('none')
+	const horizontal = orientation === 'horizontal'
+
+	function update() {
+		const el = element.value
+		if (!el) return
+
+		const scrollSize = horizontal ? el.scrollWidth : el.scrollHeight
+		const clientSize = horizontal ? el.clientWidth : el.clientHeight
+		const offset = horizontal ? el.scrollLeft : el.scrollTop
+		const overflow = scrollSize - clientSize
+
+		if (overflow <= EPSILON) {
+			mask.value = 'none'
+			return
+		}
+
+		const start = Math.round(Math.min(offset, FADE))
+		const end = Math.round(Math.min(overflow - offset, FADE))
+		const direction = horizontal ? 'to right' : 'to bottom'
+		mask.value =
+			`linear-gradient(${direction}, transparent 0, #000 ${start}px, ` +
+			`#000 calc(100% - ${end}px), transparent 100%)`
+	}
+
+	let observer: ResizeObserver | null = null
+
+	function detach(el: HTMLElement) {
+		el.removeEventListener('scroll', update)
+		observer?.disconnect()
+		observer = null
+	}
+
+	watch(
+		element,
+		(el, previous) => {
+			if (previous) detach(previous)
+			if (!el) return
+			el.addEventListener('scroll', update, { passive: true })
+			// The viewport resizes with the window; its child resizes when
+			// columns or cards come and go. Both change what overflows.
+			observer = new ResizeObserver(update)
+			observer.observe(el)
+			if (el.firstElementChild) observer.observe(el.firstElementChild)
+			update()
+		},
+		{ immediate: true },
+	)
+
+	onScopeDispose(() => {
+		if (element.value) detach(element.value)
+	})
+
+	return { mask, update }
+}


### PR DESCRIPTION
## Problem

The task board scrolls horizontally, but both edges cut off with a hard line. Nothing tells you there are more columns either way.

## Solution

New `useScrollFade` composable builds a `mask-image` from the scroller's position. Each edge's fade grows with the distance still scrollable on that side, so it eases in and out with the scroll itself — no transition to animate, and no fade at an edge you have already reached. Applied to `TaskBoard`'s horizontal `ScrollArea`.

Not verified in a browser yet — `agent-browser` had no Chrome available in this environment. Typecheck and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AupF7Eoc6JnGv1gaiQY6G